### PR TITLE
Fix typos in markdown, comments, and docstrings across the notebook

### DIFF
--- a/trec06p-cs280/naive_bayes.ipynb
+++ b/trec06p-cs280/naive_bayes.ipynb
@@ -5,7 +5,7 @@
    "id": "00e59985",
    "metadata": {},
    "source": [
-    "# Naive Bayes Classifer for Spam Email Filtering\n",
+    "# Naive Bayes Classifier for Spam Email Filtering\n",
     "\n",
     "This document outlines the implementation of a Naive Bayes classifier aimed at filtering spam emails. It details the complete process—from data collection and preprocessing to training the model and evaluating its performance—using the TREC06p dataset as a benchmark."
    ]
@@ -17,11 +17,11 @@
    "source": [
     "## Understanding the Dataset \n",
     "\n",
-    "Before we analyze and and perform analyzing strategies, we must first understand our dataset. \n",
+    "Before we analyze and perform analyzing strategies, we must first understand our dataset. \n",
     "\n",
-    "The **trec06p (Text Retrieval Conference)** dataset is benchmark dataset to test and compar the performance of various machine learning and natural language processing approaches in determining between spam and legitimate (ham) emails. \n",
+    "The **trec06p (Text Retrieval Conference)** dataset is a benchmark dataset to test and compare the performance of various machine learning and natural language processing approaches in determining between spam and legitimate (ham) emails. \n",
     "\n",
-    "The dataset is made of large collection of **emails** pre-labeled as either **spam or ham**. This clear binary classification makes it ideal for supervised learning tasks. The emails also include features such as headers, body content and even metadata, which we can use to extract informative features for classification. \n"
+    "The dataset is made up of large collection of **emails** pre-labeled as either **spam or ham**. This clear binary classification makes it ideal for supervised learning tasks. The emails also include features such as headers, body content and even metadata, which we can use to extract informative features for classification. \n"
    ]
   },
   {
@@ -37,7 +37,7 @@
    "id": "4a1c4d25",
    "metadata": {},
    "source": [
-    "The first thing to do is the import the necessary libraries and loads email data from file paths. \n",
+    "The first thing to do is to import the necessary libraries and load email data from file paths. \n",
     "\n",
     "It separates the emails into **\"ham\"** (non-spam) and **\"spam\"** lists by reading each file with a custom read_file function, while handling any errors encountered during the file reading process."
    ]
@@ -77,7 +77,7 @@
    "id": "1775b5b6",
    "metadata": {},
    "source": [
-    "We defined a **read_file** function designed to handle messy file encodings. Using the charset_normalizer library, it reads and decodes file content in the best possible encoding, returning the decoded text or raising an error if decoding fails."
+    "We defined a **read_file** function designed to handle messy file encodings."
    ]
   },
   {
@@ -240,9 +240,9 @@
    "id": "950ec52b",
    "metadata": {},
    "source": [
-    "Next, we will split the data set into testing and traing data. \n",
+    "Next, we will split the data set into testing and training data. \n",
     "\n",
-    "The split is allocated for 80% on the training data and 20% for the testing data. We chose this split because it is the most commonly used method to AI training. \n",
+    "The split is allocated for 80% on the training data and 20% for the testing data. We chose this split because it is the most commonly used method in AI training. \n",
     "\n",
     "Then, we used indices to partition the lists of emails accordingly. "
    ]
@@ -270,7 +270,7 @@
    "id": "5a6122df",
    "metadata": {},
    "source": [
-    "The next thing we do is to parse the document into words using the parse_dcocument function to preprocess the list of documents. \n",
+    "The next thing we do is to parse the document into words using the parse_documents function to preprocess the list of documents. \n",
     "\n",
     "This is done in accordance to the instruction for this programming assignment. \n",
     "\n",
@@ -323,7 +323,7 @@
    "source": [
     "The following code extracts the unique tokens or vocabulary for the ham and spam emails. This is implemented by creating a set of tokens that naturally removes any duplicates. \n",
     "\n",
-    "This is implemented in both the ham and spam documents to get to vocabularies to assess the unique words in each class"
+    "This is implemented in both the ham and spam documents to generate vocabularies to assess the unique words in each class"
    ]
   },
   {
@@ -367,7 +367,7 @@
    "id": "1e6d4c50",
    "metadata": {},
    "source": [
-    "We combine the total vocabulary by using a union operator so that each elements are unique"
+    "We combine the total vocabulary by using a union operator so that all elements are unique"
    ]
   },
   {
@@ -484,9 +484,9 @@
    "id": "7d9c9967",
    "metadata": {},
    "source": [
-    "Here, we calculate the prior probabilites for the ham and spam classes. This computes the fraction of documents in each class relative to the total number of documents in the training set. \n",
+    "Here, we calculate the prior probabilities for the ham and spam classes. This computes the fraction of documents in each class relative to the total number of documents in the training set. \n",
     "\n",
-    "Based on the results, there are higher probability in the spam emails compared to the ham emails. "
+    "Based on the results, there is a higher probability in the spam emails compared to the ham emails. "
    ]
   },
   {
@@ -643,7 +643,7 @@
    "id": "284412c3",
    "metadata": {},
    "source": [
-    "Based on these charts, the most frequently words in ham emails are the common English words — likely articles, prepositions or conjunctions. These can be classified also as stop words. \n",
+    "Based on these charts, the most frequent words in ham emails are the common English words — likely articles, prepositions or conjunctions. These can be classified also as stop words. \n",
     "\n",
     "In contrast, the spam emails display the distribution where certain terms like HTML tags in order to create attention-grabbing design in their emails. Also another thing is that HTML allows them to cloud the content in ways that might bypass basic spam filters. \n",
     "\n",
@@ -663,9 +663,9 @@
    "id": "9f96ada6",
    "metadata": {},
    "source": [
-    "This section computes the probability of each word given its class by first summing the total word counts fro ham and spam from their respective Dataframes. \n",
+    "This section computes the probability of each word given its class by first summing the total word counts for ham and spam from their respective Dataframes. \n",
     "\n",
-    "Then we calculate P(world | class) by dividing each word's count by the total count for that class. "
+    "Then we calculate P(word | class) by dividing each word's count by the total count for that class. "
    ]
   },
   {
@@ -832,9 +832,9 @@
    "source": [
     "In this code, we convert the probability columns from the dataframes into dictionaries for faster lookup. Then the predict function uses log probabilities to compute the overall likelihood of an input document belonging to either the ham or spam class. \n",
     "\n",
-    "It starts by taking the logarithm of the prior probabilites and then add the logarithm of each word's conditional probability from the dictionaries for every token in the input document. \n",
+    "It starts by taking the logarithm of the prior probabilities and then adds the logarithm of each word's conditional probability from the dictionaries for every token in the input document. \n",
     "\n",
-    "Finally, I compare the accumulated log probabilities and return 'ham' or 'spam' based on which is higher. "
+    "Finally, we compare the accumulated log probabilities and return 'ham' or 'spam' based on which is higher. "
    ]
   },
   {
@@ -889,7 +889,7 @@
    "id": "1a8996c9",
    "metadata": {},
    "source": [
-    "In this code, we extend the classifier by incorporating the Laplace Smooothing to handle the unseen words during prediction. We start by defining the smoothing factor (alpha) in this case the 0.00005 and the vocabulary size. \n",
+    "In this code, we extend the classifier by incorporating the Laplace Smoothing to handle the unseen words during prediction. We start by defining the smoothing factor (alpha) in this case the 0.0000005 and the vocabulary size. \n",
     "\n",
     "Then, we update the conditional probability calculations for both ham and spam by adding alpha to each word count and adjusting the total accordingly. \n",
     "\n",
@@ -954,7 +954,7 @@
    "source": [
     "Next, we prepare the test dataset and evaluate the classifier. We combine the ham and spam test emails into one list and construct the corresponding ground truth labels. Next, we tokenize the test documents using parse_documents. \n",
     "\n",
-    "Lastly, we define and use use a helper funcdtion that applies the Laplace-smoothed prediction to each tokenized document to generate the predicted labels. "
+    "Lastly, we define and use a helper function that applies the Laplace-smoothed prediction to each tokenized document to generate the predicted labels. "
    ]
   },
   {
@@ -1086,7 +1086,7 @@
     "acc = accuracy_score(y_test, y_pred)\n",
     "\n",
     "\n",
-    "# # Confusion matrix\n",
+    "# Confusion matrix\n",
     "cm = confusion_matrix(y_test, y_pred, labels=['ham', 'spam'])\n",
     "\n",
     "\n",
@@ -1113,7 +1113,7 @@
    "id": "0c10ec52",
    "metadata": {},
    "source": [
-    "Here, we put it all together to define the NaiveBayesClassificer class to implement the entirety of the Naive Bayes Spam Filter with Laplace Smoothing. "
+    "Here, we put it all together to define the NaiveBayesClassifier class to implement the entirety of the Naive Bayes Spam Filter with Laplace Smoothing. "
    ]
   },
   {
@@ -1185,7 +1185,7 @@
     "        total_words (int): Total word count for the given class.\n",
     "        \n",
     "        Returns:\n",
-    "        laplac smoothed probability P(word|class).\n",
+    "        laplace smoothed probability P(word|class).\n",
     "        \"\"\"\n",
     "        word_count = class_word_counts[word]\n",
     "        # Laplace smoothing: count + alpha divided by total words plus alpha * vocabulary size\n",
@@ -1247,7 +1247,7 @@
    "id": "cca81b74",
    "metadata": {},
    "source": [
-    "Here, it initialize an instance of my NaiveBayesClassifier using a smoothing parameter (alpha) of 0.05. This value controls the amount of Laplace smoothing applied during training and prediction, helping to prevent zero probabilities for unseen words."
+    "Here, it initialize an instance of the NaiveBayesClassifier using a smoothing parameter (alpha) of 0.05. This value controls the amount of Laplace smoothing applied during training and prediction, helping to prevent zero probabilities for unseen words."
    ]
   },
   {
@@ -1257,7 +1257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize the model with some random lambda vfalue\n",
+    "# Initialize the model with some random lambda value\n",
     "model = NaiveBayesClassifier(alpha=0.05)"
    ]
   },
@@ -1340,7 +1340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "id": "5c1d3d95",
    "metadata": {},
    "outputs": [
@@ -1394,7 +1394,7 @@
     "# Optional: Full classification report\n",
     "print(\"\\nClassification Report:\\n\", classification_report(y_test, y_pred))\n",
     "\n",
-    "# # Report\n",
+    "# Report\n",
     "# report = classification_report(y_true, y_pred, labels=['ham', 'spam'])\n"
    ]
   },
@@ -1403,7 +1403,7 @@
    "id": "4b71a5a5",
    "metadata": {},
    "source": [
-    "In this block, we defined a helper function called compute_precision_recall that calculates the precision and recall metrics for my spam classifier. I assume that:\n",
+    "In this block, we defined a helper function called compute_precision_recall that calculates the precision and recall metrics for my spam classifier. we assume that:\n",
     "\n",
     "- TP (True Positives): Spam emails correctly predicted as spam.\n",
     "- FP (False Positives): Ham emails misclassified as spam.\n",
@@ -1444,7 +1444,7 @@
    "id": "5ecc060c",
    "metadata": {},
    "source": [
-    "Here, we evaluate how different Laplace smoothing Parameteres (lambda values) affect the classifier's performance. We first tokenize the test documents, then define a function **evaluate_with_lambdas**. \n",
+    "Here, we evaluate how different Laplace smoothing parameters (lambda values) affect the classifier's performance. We first tokenize the test documents, then define a function **evaluate_with_lambdas**. \n",
     "\n",
     "- Iterates over a list of lambda values.\n",
     "- For each lambda, creates a new classifier instance and fits it using the tokenized ham and spam training documents.\n",
@@ -1516,9 +1516,9 @@
    "source": [
     "In this block, we calculate the \"informative words\" based on the log odds ratio of each word's likelihood in spam versus ham emails. \n",
     "\n",
-    "For each word in the classifier's vocabulary, I compute its smoothed conditional probabilities in both classes and then calculate the log odds ratio (positive scores favor spam; negative scores favor ham). \n",
+    "For each word in the classifier's vocabulary, we compute its smoothed conditional probabilities in both classes and then calculate the log odds ratio (positive scores favor spam; negative scores favor ham). \n",
     "\n",
-    "After sorting these scores by their absolute values to identify the most discriminative words, I extract the top 200 informative words. Finally, I separate and print the top 10 words that are most indicative of spam and the top 10 that are most indicative of ham."
+    "After sorting these scores by their absolute values to identify the most discriminative words, we extract the top 200 informative words. Finally, we separate and print the top 10 words that are most indicative of spam and the top 10 that are most indicative of ham."
    ]
   },
   {
@@ -1588,7 +1588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "id": "511a00e4",
    "metadata": {},
    "outputs": [
@@ -1604,7 +1604,7 @@
     "# Create a set of the top 200 informative words\n",
     "informative_vocabulary = set([word for word, score in top_informative])\n",
     "\n",
-    "# Modifyng the prediction function to ignore words not in informative_vocabulary:\n",
+    "# Modifying the prediction function to ignore words not in informative_vocabulary:\n",
     "def predict_with_informative(classifier, document_tokens, informative_vocabulary):\n",
     "    # Only consider tokens that are in the informative vocabulary\n",
     "    filtered_tokens = [word for word in document_tokens if word in informative_vocabulary]\n",


### PR DESCRIPTION
Did this pull request to propose changes focusing on correcting typos, grammatical issues, and minor inaccuracies in the `trec06p-cs280/naive_bayes.ipynb` notebook for improving our documentation quality. The changes vary in the different sections of the notebook, including headers, function descriptions, and comments, so kindly check it nalang din. Thank you and cheers 🍻!